### PR TITLE
fixing issue with include_recipe in a LWRP cookbook

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -1,5 +1,5 @@
 action :add do
-  include_recipe "sysctl::service"
+  run_context.include_recipe "sysctl::service"
 
   sysctld_file = template ::File.join("/etc/sysctl.d/", "#{new_resource.name}.conf") do
     source "sysctl.d.erb"
@@ -15,7 +15,7 @@ action :add do
 end
 
 action :remove do
-  include_recipe "sysctl::service"
+  run_context.include_recipe "sysctl::service"
 
   sysctld_file = file ::File.join("/etc/sysctl.d/", "#{new_resource.name}.conf") do
     action :delete


### PR DESCRIPTION
using plain "include_recipe" in LWRPs fails with:

```
================================================================================
Error executing action `add` on resource 'sysctl_d[90-vm.swappiness]'
================================================================================

NoMethodError
-------------
No resource or method named `include_recipe' for `Chef::Provider::SysctlD ""'
```

you need to preface it with "run_context.include_recipe"
